### PR TITLE
fix(worker): support SPA fallback routing for nested slide paths

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -15,8 +15,20 @@ export default {
       if (path === "" || path.endsWith("/")) {
         object = await env.ASSETS.get(path + "index.html");
       } else if (!path.includes(".")) {
-        // Try with /index.html appended
-        object = await env.ASSETS.get(path + "/index.html");
+        // For SPA routing: find the nearest index.html by walking up the path
+        // e.g., "2025-10-25/6" should serve "2025-10-25/index.html"
+        const segments = path.split("/").filter(Boolean);
+        while (segments.length > 0 && !object) {
+          const basePath = segments.join("/") + "/index.html";
+          object = await env.ASSETS.get(basePath);
+          if (!object) {
+            segments.pop();
+          }
+        }
+        // Fallback to root index.html if no nested index.html found
+        if (!object) {
+          object = await env.ASSETS.get("index.html");
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Fix 404 errors when accessing slide-specific URLs like `/2025-10-25/6`
- Worker now finds the nearest `index.html` by traversing up the path segments
- Allows Vue Router to handle client-side navigation to specific slides

## Test plan
- [ ] Deploy to Cloudflare Workers
- [ ] Verify `https://slides.naito.dev/2025-10-25/6` loads correctly
- [ ] Verify `https://slides.naito.dev/2025-10-25/` still works
- [ ] Verify other presentations still work

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)