### PR TITLE
feat: add homepage with slides list at root URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "eslint-plugin-format": "catalog:lint",
     "execa": "^9.5.2",
     "fast-glob": "^3.3.2",
+    "gray-matter": "^4.0.3",
+    "gunshi": "catalog:script",
     "markdown-it-magic-link": "catalog:slidev",
     "playwright-chromium": "catalog:slidev",
     "pnpm": "^9.5.0",
@@ -59,7 +61,6 @@
     "unocss": "catalog:slidev",
     "vue": "catalog:slidev",
     "vue-router": "catalog:slidev",
-    "gunshi": "catalog:script",
     "vue-tsc": "catalog:slidev"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.3
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       gunshi:
         specifier: catalog:script
         version: 0.27.5

--- a/scripts/build-all.ts
+++ b/scripts/build-all.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { cli, define } from "gunshi";
 import { execa } from "execa";
+import matter from "gray-matter";
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const distDir = path.join(rootDir, "dist");
@@ -112,6 +113,148 @@ async function buildAll() {
   }
 
   console.log(`\nAll slides built to ${distDir}`);
+
+  // Generate homepage
+  await generateHomepage(slideFolders);
+}
+
+interface SlideInfo {
+  folder: string;
+  title: string;
+  date: string;
+}
+
+async function generateHomepage(slideFolders: string[]) {
+  console.log("\nGenerating homepage...");
+
+  const slides: SlideInfo[] = [];
+
+  for (const folder of slideFolders) {
+    const slidesPath = path.join(rootDir, folder, "src", "slides.md");
+    try {
+      const content = await fs.readFile(slidesPath, "utf-8");
+      const { data } = matter(content);
+      const title = data.title || data.info?.split("\n")[0]?.replace(/^##\s*/, "") || folder;
+      slides.push({
+        folder,
+        title,
+        date: folder,
+      });
+    } catch {
+      slides.push({
+        folder,
+        title: folder,
+        date: folder,
+      });
+    }
+  }
+
+  // Sort by date descending (newest first)
+  slides.sort((a, b) => b.date.localeCompare(a.date));
+
+  const html = generateHomepageHtml(slides);
+  await fs.writeFile(path.join(distDir, "index.html"), html);
+  console.log("✓ Homepage generated");
+}
+
+function generateHomepageHtml(slides: SlideInfo[]): string {
+  const slideItems = slides
+    .map(
+      (slide) => `
+      <a href="/${slide.folder}/" class="slide-card">
+        <span class="date">${slide.date}</span>
+        <span class="title">${escapeHtml(slide.title)}</span>
+      </a>`
+    )
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Slides - naitokosuke</title>
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background: #0f0f0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+    .container {
+      max-width: 800px;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 2rem;
+      color: #fff;
+    }
+    .slides-list {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+    .slide-card {
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+      padding: 1.25rem 1.5rem;
+      background: #1a1a1a;
+      border-radius: 8px;
+      text-decoration: none;
+      color: inherit;
+      transition: background 0.2s, transform 0.2s;
+    }
+    .slide-card:hover {
+      background: #252525;
+      transform: translateX(4px);
+    }
+    .date {
+      font-family: "JetBrains Mono", monospace;
+      font-size: 0.875rem;
+      color: #888;
+      white-space: nowrap;
+    }
+    .title {
+      font-size: 1.125rem;
+      color: #fff;
+    }
+    @media (max-width: 600px) {
+      body {
+        padding: 1rem;
+      }
+      .slide-card {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Slides</h1>
+    <div class="slides-list">
+${slideItems}
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
 }
 
 const command = define({


### PR DESCRIPTION
## Summary
- Add homepage at `https://slides.naito.dev/` showing all slides
- Parse slide frontmatter to extract titles using gray-matter
- Generate static `index.html` at build time
- Dark theme with responsive design

## Implementation
- Modified `scripts/build-all.ts` to generate homepage after building all slides
- Extract `title` from each `slides.md` frontmatter (falls back to `info` field or folder name)
- Sort slides by date descending (newest first)

## Test plan
- [ ] Run `pnpm run build:ci` locally to verify homepage generation
- [ ] Deploy and verify `https://slides.naito.dev/` shows slide list
- [ ] Verify clicking a slide links to the correct presentation

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)