### PR TITLE
feat: add OGP image generation and seoMeta for all slides

### DIFF
--- a/2024-08-02/src/slides.md
+++ b/2024-08-02/src/slides.md
@@ -10,6 +10,11 @@ transition: fade-out
 fonts:
   sans: "Kiwi Maru "
   mono: "Fira Code"
+seoMeta:
+  ogTitle: 東葛.dev #1
+  ogImage: https://slides.naito.dev/2024-08-02/og-image.png
+  ogUrl: https://slides.naito.dev/2024-08-02/
+  twitterCard: summary_large_image
 ---
 
 # 東葛.dev #1

--- a/2024-08-03/src/slides.md
+++ b/2024-08-03/src/slides.md
@@ -13,6 +13,11 @@ mdc: true
 fonts:
   sans: "Kosugi Maru"
   mono: "Fira Code"
+seoMeta:
+  ogTitle: Python でファクトリメソッド？
+  ogImage: https://slides.naito.dev/2024-08-03/og-image.png
+  ogUrl: https://slides.naito.dev/2024-08-03/
+  twitterCard: summary_large_image
 ---
 
 <h1><span>Python でファクトリメソッド？</span></h1>

--- a/2024-09-07/src/slides.md
+++ b/2024-09-07/src/slides.md
@@ -9,6 +9,11 @@ transition: slide-left
 fonts:
   sans: "Kosugi Maru"
   mono: "Fira Code"
+seoMeta:
+  ogTitle: V が名前に入ってる
+  ogImage: https://slides.naito.dev/2024-09-07/og-image.png
+  ogUrl: https://slides.naito.dev/2024-09-07/
+  twitterCard: summary_large_image
 ---
 
 <h1>V <span v-click>が名前に入ってる</span></h1>

--- a/2024-09-14/src/slides.md
+++ b/2024-09-14/src/slides.md
@@ -1,5 +1,6 @@
 ---
 theme: default
+title: V が名前に入ってる
 info: |
   ## 「V が名前に入ってる」
   Funabashi.dev supported by KIKKAKE CREATION 2024.09.14
@@ -8,6 +9,11 @@ transition: slide-left
 fonts:
   sans: "Kosugi Maru"
   mono: "Fira Code"
+seoMeta:
+  ogTitle: V が名前に入ってる
+  ogImage: https://slides.naito.dev/2024-09-14/og-image.png
+  ogUrl: https://slides.naito.dev/2024-09-14/
+  twitterCard: summary_large_image
 ---
 
 <h1>V <span v-click>が名前に入ってる</span></h1>

--- a/2024-09-26/src/slides.md
+++ b/2024-09-26/src/slides.md
@@ -1,5 +1,6 @@
 ---
 theme: default
+title: 自己紹介
 fonts:
   sans: "Noto Sans JP"
 info: |
@@ -9,6 +10,11 @@ drawings:
   persist: false
 transition: slide-left
 mdc: true
+seoMeta:
+  ogTitle: 自己紹介
+  ogImage: https://slides.naito.dev/2024-09-26/og-image.png
+  ogUrl: https://slides.naito.dev/2024-09-26/
+  twitterCard: summary_large_image
 ---
 
 <h1>自己紹介</h1>

--- a/2025-09-13/src/slides.md
+++ b/2025-09-13/src/slides.md
@@ -1,6 +1,12 @@
 ---
 theme: default
+title: Vue を仕事で書くようになりました
 transition: slide-left
+seoMeta:
+  ogTitle: Vue を仕事で書くようになりました
+  ogImage: https://slides.naito.dev/2025-09-13/og-image.png
+  ogUrl: https://slides.naito.dev/2025-09-13/
+  twitterCard: summary_large_image
 ---
 
 # Vue を仕事で書くようになりました

--- a/2025-10-26/src/slides.md
+++ b/2025-10-26/src/slides.md
@@ -6,6 +6,11 @@ fonts:
   sans: "Noto Sans JP"
   serif: "Murecho"
   mono: "JetBrains Mono"
+seoMeta:
+  ogTitle: 最高の DX - Nuxt Typed Router と Pinia Colada で実現する次世代 Vue/Nuxt 開発
+  ogImage: https://slides.naito.dev/2025-10-26/og-image.png
+  ogUrl: https://slides.naito.dev/2025-10-26/
+  twitterCard: summary_large_image
 ---
 
 # 最高の DX - Nuxt Typed Router と Pinia Colada で実現する次世代 Vue/Nuxt 開発

--- a/2025-12-13/src/slides.md
+++ b/2025-12-13/src/slides.md
@@ -16,6 +16,11 @@ fonts:
 mdc: true
 
 transition: slide-left
+seoMeta:
+  ogTitle: 公式が勝手に言ってるだけ
+  ogImage: https://slides.naito.dev/2025-12-13/og-image.png
+  ogUrl: https://slides.naito.dev/2025-12-13/
+  twitterCard: summary_large_image
 ---
 
 # 公式が勝手に言ってるだけ


### PR DESCRIPTION
## Summary

- ビルド時に各スライドの1枚目をPNGとしてエクスポートし、OGP画像として配置
- 全スライドに `seoMeta` frontmatter を追加

## Changes

### `scripts/build-all.ts`
- `generateOgImages()` 関数を追加
- `slidev export --format png --range 1` で1枚目をエクスポート
- 手動でOG画像を作成済みのスライド (2025-10-25, 2025-06-17) はスキップ

### 各スライドの `slides.md`
以下のスライドに `seoMeta` を追加:
- 2024-08-02, 2024-08-03, 2024-09-07, 2024-09-14, 2024-09-26
- 2025-09-13, 2025-10-26, 2025-12-13

## Test plan

- [ ] ローカルでビルドして OG 画像が生成されることを確認
- [ ] 生成された HTML に meta タグが含まれることを確認

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)